### PR TITLE
Add runtime warning for long local model runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ npm run dev -- --host
 
 - Desktop browsers are the target environment.
 - `WebGPU` is preferred for reasonable performance.
+- First load can take a while because the models have to download and initialize in the browser.
+- On slower machines, memory-constrained browsers, or weaker GPU/browser combinations, the tab may become unresponsive or crash while the models load or run.
 - If `WebGPU` is unavailable, the app attempts a `WASM` fallback, which may be slow.
 - The text rewrite model is loaded lazily after the vision model so the app keeps the current flow and only adds the second stage when needed for generation.
 - Mobile Safari and Chrome are intentionally blocked because the local model load is likely to crash or be killed by memory limits.
@@ -107,5 +109,6 @@ public/
 ## Limitations
 
 - The app depends on client-side model downloads, so first load can take time.
+- Heavy local inference can still freeze or crash a browser tab on some machines even on desktop.
 - Browser support and performance depend heavily on `WebGPU`.
 - This is a local browser demo, not a production-grade accessibility audit tool.

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,12 @@ const TRACE_EXPLAINER = [
   `The loop stops as soon as a rewrite fits within ${ALT_TEXT_CHARACTER_LIMIT} characters, or fails after ${MAX_REWRITE_LOOPS} passes.`,
 ].join('\n');
 
+const RUNTIME_WARNING = [
+  'Local browser inference can take a while, especially on the first run while models download and initialize.',
+  'On slower machines or browsers without stable WebGPU support, the tab may become unresponsive or crash during loading or generation.',
+  'Desktop with WebGPU is strongly recommended.',
+].join('\n\n');
+
 interface ViewState {
   appState: AppState;
   image: File | null;
@@ -149,6 +155,13 @@ export function mountApp(root: HTMLDivElement): void {
             <span class="hint">PNG, JPEG, WebP, GIF. Max 10 MB.</span>
           </label>
 
+          <button id="run-button" class="run-button" type="button">Generate alt text</button>
+
+          <section class="warning-card">
+            <span class="warning-label">Before you run</span>
+            <pre class="warning-body">${RUNTIME_WARNING}</pre>
+          </section>
+
           <section class="field">
             <span class="label">Flow</span>
             <pre class="prompt-display">${ALT_TEXT_STRATEGY}</pre>
@@ -163,8 +176,6 @@ export function mountApp(root: HTMLDivElement): void {
             <span class="label">Rewrite loop</span>
             <pre class="prompt-display">${TRACE_EXPLAINER}</pre>
           </section>
-
-          <button id="run-button" class="run-button" type="button">Generate alt text</button>
         </div>
 
         <div class="column output">

--- a/src/style.css
+++ b/src/style.css
@@ -98,6 +98,7 @@ img {
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
   gap: 24px;
   padding: 24px;
+  align-items: start;
 }
 
 .column {
@@ -119,6 +120,16 @@ img {
   border: 1px solid var(--border);
 }
 
+.warning-card {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(90, 50, 18, 0.48) 0%, rgba(47, 26, 12, 0.78) 100%);
+  border: 1px solid rgba(243, 139, 49, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(243, 139, 49, 0.08);
+}
+
 .label,
 .status-label,
 .result-label {
@@ -127,6 +138,26 @@ img {
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+.warning-label {
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ffd39d;
+}
+
+.warning-body {
+  margin: 0;
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 211, 157, 0.14);
+  border-radius: 16px;
+  background: rgba(18, 11, 6, 0.45);
+  color: #fff2df;
+  white-space: pre-wrap;
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', monospace;
+  font-size: 0.92rem;
 }
 
 .hint {
@@ -224,6 +255,7 @@ textarea:focus-visible,
 .output {
   display: grid;
   gap: 18px;
+  align-content: start;
 }
 
 .preview-grid {


### PR DESCRIPTION
## Summary
- add a prominent in-app warning that local inference can take a while and may crash the browser tab
- add matching runtime and limitation notes to the README
- keep the warning visible before the user starts generation

## Testing
- npm run build

Closes #2